### PR TITLE
feat: omit triggers for true

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -53,8 +53,8 @@ jobs:
           echo "needs.test-omitted.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: true"
 
       - if:
-          needs.test-true.outputs.triggered != 'true' || \
-          needs.test-false.outputs.triggered != 'false' || \
+          needs.test-true.outputs.triggered != 'true' ||
+          needs.test-false.outputs.triggered != 'false' ||
           needs.test-omitted.outputs.triggered != 'true'
         run: |
           exit 1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -52,6 +52,7 @@ jobs:
           needs.test-false.outputs.triggered != 'false' ||
           needs.test-omitted.outputs.triggered != 'true'
         run: |
+          # Explain any errors
           echo "needs.test-true.outputs.triggered: ${{ needs.test-true.outputs.triggered }} - expected: true"
           echo "needs.test-false.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: false"
           echo "needs.test-omitted.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: true"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,17 +44,15 @@ jobs:
 
   results:
     name: Results
-    needs: [test-true, test-false]
+    needs: [test-true, test-false, test-omitted]
     runs-on: ubuntu-22.04
     steps:
-      - run: |
-          echo "needs.test-true.outputs.triggered: ${{ needs.test-true.outputs.triggered }} - expected: true"
-          echo "needs.test-false.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: false"
-          echo "needs.test-omitted.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: true"
-
       - if:
           needs.test-true.outputs.triggered != 'true' ||
           needs.test-false.outputs.triggered != 'false' ||
           needs.test-omitted.outputs.triggered != 'true'
         run: |
+          echo "needs.test-true.outputs.triggered: ${{ needs.test-true.outputs.triggered }} - expected: true"
+          echo "needs.test-false.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: false"
+          echo "needs.test-omitted.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: true"
           exit 1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -32,15 +32,29 @@ jobs:
         with:
           triggers: ('path/to/nowhere')
 
+  test-omitted:
+    name: Test for Omitted
+    outputs:
+      triggered: ${{ steps.test.outputs.triggered }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        id: test
+
   results:
     name: Results
     needs: [test-true, test-false]
     runs-on: ubuntu-22.04
     steps:
       - run: |
-          echo "needs.test-true.outputs.triggered: ${{ needs.test-true.outputs.triggered }}"
-          echo "needs.test-false.outputs.triggered: ${{ needs.test-false.outputs.triggered }}"
+          echo "needs.test-true.outputs.triggered: ${{ needs.test-true.outputs.triggered }} - expected: true"
+          echo "needs.test-false.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: false"
+          echo "needs.test-omitted.outputs.triggered: ${{ needs.test-false.outputs.triggered }} - expected: true"
 
-      - if: needs.test-true.outputs.triggered != 'true' || needs.test-false.outputs.triggered != 'false'
+      - if:
+          needs.test-true.outputs.triggered != 'true' || \
+          needs.test-false.outputs.triggered != 'false' || \
+          needs.test-omitted.outputs.triggered != 'true'
         run: |
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -6,9 +6,11 @@ branding:
 
 inputs:
   ### Required
+  # Nothing!
+
+  ### Typical / recommended
   triggers:
-    description: Paths used to trigger an event; e.g. ('./backend/' './frontend/)
-    required: true
+    description: Paths used to trigger an event; e.g. ('./backend/' './frontend/); always trigger if omitted
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -29,6 +31,13 @@ runs:
       shell: bash
       id: diff
       run: |
+        # Always fire if triggers are omitted
+        if [ -z "${{ inputs.triggers }}" ]; then
+          echo "Always fire when triggers are omitted!"
+          echo "triggered=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Build if changed files (git diff) match triggers
         TRIGGERS=${{ inputs.triggers }}
         git fetch origin ${{ inputs.diff_branch }}
@@ -45,5 +54,5 @@ runs:
         done < <(git diff origin/${{ inputs.diff_branch }} --name-only)
 
         # If at this point, no trigger has fired
-        echo "Container build not required"
+        echo "Triggers have not fired"
         echo "triggered=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
bcgov-nr/action-diff-triggers should return true when triggers are omitted. This matches the pattern in bcgov/quickstart-openshift, where not using triggers means to always deploy.

Closes https://github.com/bcgov/quickstart-openshift/issues/1837